### PR TITLE
Redirect to production when env is set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 SECRET_KEY_BASE='b344a473c5c511db8af00acf6c61eaecda95b6cbc5693b14b2b876442b72c32302256e439cb7ece9ec432f12a43204d7b6baeb1ab1bf8d95e4da672f54295557'
+
+# When set, the project will be permanently redirected to this URL
+PRODUCTION_URL=''

--- a/app/controllers/crawlers_controller.rb
+++ b/app/controllers/crawlers_controller.rb
@@ -1,5 +1,8 @@
 class CrawlersController < ApplicationController
   def index
+    if ENV['PRODUCTION_URL'].present?
+      redirect_to ENV['PRODUCTION_URL'], status: 301
+    end
   end
 
   def create


### PR DESCRIPTION
I am making the oficial website the one under the `colab.dev` domain, but I don't like to lose the index of Heroku's website. So, I am redirecting from Heroku to the new one, but only if an env is set.