### PR TITLE
Add execjs gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'jbuilder', '~> 2.5'
 
 gem 'colorize'
 gem 'dotenv-rails'
+gem 'execjs'
 gem 'mechanize'
 gem 'pg'
 gem 'rack', '2.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,6 +259,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   colorize
   dotenv-rails
+  execjs
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)


### PR DESCRIPTION
I am trying to deploy this project to Railway.app and there is an error complaining about js runtime:

```
Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.
```

This gem may solve the problem.