### PR TITLE
Remove execjs gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ gem 'jbuilder', '~> 2.5'
 
 gem 'colorize'
 gem 'dotenv-rails'
-gem 'execjs'
 gem 'mechanize'
 gem 'pg'
 gem 'rack', '2.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,7 +259,6 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   colorize
   dotenv-rails
-  execjs
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)


### PR DESCRIPTION
[This PR](https://github.com/arturcp/skoob-exporter/pull/58) did not work, the deploy to Render.com is still not working, which means the `execjs` gem is no longer needed and is being removed on this PR.