### PR TITLE
Update procfile to run web server

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 worker: bundle exec sidekiq -c 3 -v
+web: bundle exec rails server -p $PORT


### PR DESCRIPTION
Our procfile has instructions to run sidekiq, but not to run the webserver. This PR adds this instructions.