### PR TITLE
Remove ssl enforcement

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,14 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  before_action :force_http
+
+  private
+
+  def force_http
+    if request.ssl?
+      response.headers['Strict-Transport-Security'] = 'max-age=0; includeSubDomains'
+      redirect_to protocol: 'http://', status: :moved_permanently
+    end
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = false
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,4 +88,6 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.secret_key_base = ENV["SECRET_KEY_BASE"]
+
+  config.action_controller.default_protect_from_forgery = false
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,6 +88,4 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.secret_key_base = ENV["SECRET_KEY_BASE"]
-
-  config.action_controller.default_protect_from_forgery = false
 end

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -18,4 +18,4 @@ ActiveSupport.to_time_preserves_timezone = true
 Rails.application.config.active_record.belongs_to_required_by_default = true
 
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
-Rails.application.config.ssl_options = { hsts: { subdomains: true } }
+Rails.application.config.ssl_options = false

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_skoob-crawler_session'
+Rails.application.config.session_store :cookie_store, key: '_skoob-crawler_session', secure: false


### PR DESCRIPTION
I am moving the project to a new server and I need this app to open on a browser without `https` so I can generate a ssl certificate using Let's Encrypt.

However, although there is no nginx configuration to enforce https, Rails itself is doing that. This PR makes some changes to make sure the site will open using http.