### PR TITLE
Remove redirect rule

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,5 @@
 SECRET_KEY_BASE='b344a473c5c511db8af00acf6c61eaecda95b6cbc5693b14b2b876442b72c32302256e439cb7ece9ec432f12a43204d7b6baeb1ab1bf8d95e4da672f54295557'
 
-# When set, the project will be permanently redirected to this URL
-PRODUCTION_URL=''
-
 GOOGLE_ANALYTICS_CODE=''
 SLACK_WEBHOOK=''
 SLACK_CHANNEL='#skoob-exporter'

--- a/app/controllers/crawlers_controller.rb
+++ b/app/controllers/crawlers_controller.rb
@@ -1,10 +1,4 @@
 class CrawlersController < ApplicationController
-  def index
-    if ENV['PRODUCTION_URL'].present?
-      redirect_to ENV['PRODUCTION_URL'], status: 301
-    end
-  end
-
   def create
     user = SkoobUser.login(params[:email], params[:password])
 


### PR DESCRIPTION
This rule was once created because I needed to redirect skoob exporter from one server to the other. This rule is no longer needed, so I am going to ✂️  it.