### PR TITLE
Export comic books and magazines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Skoob Exporter
 
-Skoob has no public API and does not provide an easy way to export your books to
-other social networks like Goodreads.
+[Skoob](https://skoob.com.br/) has no public API and does not provide an easy way to export your publications (books, comics, and magazines) to other social networks like [Goodreads](https://www.goodreads.com/).
 
-To fix that, this project gets information about all your books and generates
-a csv file in the format Goodreads expect, so you can easily
+To fix that, this project imports all publications from your Skoob account and generates
+a CSV file in the format that Goodreads expect, so you can easily
 [import it here](https://www.goodreads.com/review/import).
 
 **[Check the website](http://skoob-exporter.colabs.dev)**
@@ -42,14 +41,14 @@ At the end of the script, it will provide your skoob id. It is a number like
 
 Remember to replace `999999` with your skoob id. The instructions to generate the
 csv will also be provided by the skoob:import task, so you don't need to remember
-the command to generate the csv.
+the command to generate the CSV.
 
 # How to run in the web
 
 Access the root url and provide your skoob credentials. Once you submit, you
 will be redirected to a page that will wait until the process is over. It will
-hold the user there and be pooling from time to time. When all books are imported,
-it will generate the .csv file and the browser will download it.
+hold the user there and be pooling from time to time. When all publications are imported,
+it will generate the CSV file and the browser will download it.
 
 # How to run it locally
 
@@ -85,12 +84,12 @@ bin/rails s
 
 # Clean up job
 
-When a user imports his/her books, they are going to be saved into the `books` table. This table is going to be used to generate the csv file. After the csv file is generated, the books are not needed anymore. To clean up the database, run:
+When a user imports publications, each one of them will be saved into the `publications` table. This table is going to be used to generate the CSV file. After the CSV is generated, the publications are not needed anymore. To clean up the database, run:
 
 ```
 bin/rake skoob:clean_up
 ```
 
-This will delete books older than 1 day ago (or books that have no `created_at` set. That happens because the timestamp was added with the website up and running, so any book created pior to the timestamp migration will have `null` as the created_at value).
+This will delete publications older than 1 day ago (or publications that have no `created_at` set. That happens because the timestamp was added with the website up and running, so any book created pior to the timestamp migration will have `null` as the created_at value).
 
 The clean up job is scheduled to run every day at 3am (UTC).

--- a/app/controllers/crawlers_controller.rb
+++ b/app/controllers/crawlers_controller.rb
@@ -5,7 +5,7 @@ class CrawlersController < ApplicationController
     user = SkoobUser.login(params[:email], params[:password])
 
     if user.skoob_user_id > 0
-      Book.where(skoob_user_id: user.skoob_user_id).destroy_all
+      Publication.where(skoob_user_id: user.skoob_user_id).destroy_all
 
       user.update(import_status: 1)
       SkoobImporterJob.perform_later(user)
@@ -21,7 +21,7 @@ class CrawlersController < ApplicationController
   def show
     @user = SkoobUser.find_by(skoob_user_id: params[:id])
 
-    if @user.import_status == 0 && Book.where(skoob_user_id: @user.skoob_user_id).count == 0
+    if @user.import_status == 0 && Publication.where(skoob_user_id: @user.skoob_user_id).count == 0
       redirect_to root_path
     end
   end
@@ -29,7 +29,7 @@ class CrawlersController < ApplicationController
   private
 
   def send_slack_notification(skoob_user_id)
-    message = "User #{skoob_user_id} is importing books right now"
+    message = "User #{skoob_user_id} is importing publications right now"
     Slack::Message.send(message)
   end
 end

--- a/app/controllers/exporter_controller.rb
+++ b/app/controllers/exporter_controller.rb
@@ -3,7 +3,7 @@ class ExporterController < ApplicationController
     csv = Exporter.new(skoob_user_id).generate_csv
     send_slack_notification(csv)
 
-    file_name = "skoob_books_#{skoob_user_id}.csv"
+    file_name = "skoob_publications_#{skoob_user_id}.csv"
 
     # Set the response headers
     headers['Content-Disposition'] = "attachment; filename=\"#{file_name}\""
@@ -23,8 +23,8 @@ class ExporterController < ApplicationController
   end
 
   def send_slack_notification(csv)
-    books = csv.split("\n").length - 1
-    message = "User #{skoob_user_id} has just exported #{books} books from Skoob!"
+    publications = csv.split("\n").length - 1
+    message = "User #{skoob_user_id} has just exported #{publications} publications from Skoob!"
     Slack::Message.send(message)
   end
 end

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -3,17 +3,17 @@ class StatusController < ApplicationController
     user = SkoobUser.find_by(skoob_user_id: params[:id])
 
     if user
-      books = user.import_status == 0 ? Book.where(skoob_user_id: params[:id]) : []
+      publications = user.import_status == 0 ? Publication.where(skoob_user_id: params[:id]) : []
 
       render json: {
         status: user.import_status,
         duplicated: user.not_imported,
-        count: user.books.count,
-        total: user.books_count,
-        books: books
+        count: user.publications.count,
+        total: user.publications_count,
+        publications: publications
       }
     else
-      render json: { status: 0, duplicated: [], count: 0, total: 0, books: [] }
+      render json: { status: 0, duplicated: [], count: 0, total: 0, publications: [] }
     end
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -71,6 +71,12 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 });
 
+const PUBLICATION_TYPES = {
+  'book': 'Livro',
+  'comic': 'HQ',
+  'magazine': 'Revista',
+};
+
 function checkImportStatus(url) {
   console.log("checking status...");
   const xhr = new XMLHttpRequest();
@@ -119,14 +125,14 @@ function checkImportStatus(url) {
         importingCard.style.display = 'none';
 
         const tableBody = document.querySelector('[data-table-card-body]');
-        data.books.forEach((item) => {
+        data.publications.forEach((item) => {
           const tr = document.createElement('tr');
-          tr.innerHTML = '<td>' + item.title + '</td><td>' + item.author + '</td><td>' + item.isbn + '</td><td>' + item.publisher + '</td><td>';
+          tr.innerHTML = `<td>${item.title}</td><td>${item.author}</td><td>${item.isbn}</td><td>${item.publisher}</td><td>${PUBLICATION_TYPES[item.publication_type] || ''}</td>`
           tableBody.appendChild(tr);
         });
 
         const tableTitle = document.querySelector('[data-table-card-title]');
-        tableTitle.textContent = `Livros importados: ${data.books.length}`;
+        tableTitle.textContent = `Publicações importadas: ${data.publications.length}`;
 
         const resultsTable = document.querySelector('.results-table');
         resultsTable.style.display = 'block';

--- a/app/jobs/skoob_importer_job.rb
+++ b/app/jobs/skoob_importer_job.rb
@@ -4,6 +4,6 @@ class SkoobImporterJob < ActiveJob::Base
   sidekiq_options retry: 0, dead: false
 
   def perform(user)
-    Skoob.fetch_books!(user) if user
+    Skoob.fetch_publications!(user) if user
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,3 +1,0 @@
-class Book < ActiveRecord::Base
-  belongs_to :skoob_user, primary_key: 'skoob_user_id'
-end

--- a/app/models/exporter.rb
+++ b/app/models/exporter.rb
@@ -10,14 +10,14 @@ class Exporter
         'Publisher', 'Binding', 'Year Published', 'Original Publication Year',
         'Date Read', 'Date Added', 'Bookshelves', 'My Review']
 
-    books = Book.where(skoob_user_id: @skoob_user_id)
+    publications = Publication.where(skoob_user_id: @skoob_user_id)
 
     CSV.generate(headers: true) do |csv|
       csv << header
 
-      books.each do |book|
-        csv << [book.title, book.author, book.isbn, nil, nil,
-          book.publisher, nil, book.year, book.year,
+      publications.each do |publication|
+        csv << [publication.title, publication.author, publication.isbn, nil, nil,
+          publication.publisher, nil, publication.year, publication.year,
           nil, nil, nil, nil]
       end
     end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -1,0 +1,9 @@
+class Publication < ActiveRecord::Base
+  belongs_to :skoob_user, primary_key: 'skoob_user_id'
+
+  enum publication_type: {
+    book: 0,
+    comic: 1,
+    magazine: 2
+  }
+end

--- a/app/models/skoob.rb
+++ b/app/models/skoob.rb
@@ -2,11 +2,11 @@ require 'rubygems'
 require 'mechanize'
 
 class Skoob
-  def self.fetch_books!(user)
+  def self.fetch_publications!(user)
     raise InvalidCredentialsError.new('Invalid credentials') unless user.skoob_user_id > 0
 
     user.import_library do |skoob_user|
-      Bookshelf.new(skoob_user).read
+      Publications.new(skoob_user).import
     end
   end
 end

--- a/app/models/skoob_urls.rb
+++ b/app/models/skoob_urls.rb
@@ -1,23 +1,23 @@
 class SkoobUrls
   SKOOB_URL = 'https://www.skoob.com.br'
 
-  def self.bookshelf_url(user_id:, page: 1, type:)
+  def self.shelf_url(user_id:, page: 1, type:)
     "#{SKOOB_URL}/v1/bookcase/#{type}/#{user_id}/shelf_id:0/page:#{page}/limit:36"
   end
 
   def self.books_shelf_url(user_id, page = 1)
-    bookshelf_url(user_id: user_id, page: page, type: 'books')
+    shelf_url(user_id: user_id, page: page, type: 'books')
   end
 
   def self.comics_shelf_url(user_id, page = 1)
-    bookshelf_url(user_id: user_id, page: page, type: 'comics')
+    shelf_url(user_id: user_id, page: page, type: 'comics')
   end
 
   def self.magazines_shelf_url(user_id, page = 1)
-    bookshelf_url(user_id: user_id, page: page, type: 'magazines')
+    shelf_url(user_id: user_id, page: page, type: 'magazines')
   end
 
-  def self.book_page_url(book_slug)
-    "#{SKOOB_URL}#{book_slug}"
+  def self.publication_page_url(publication_slug)
+    "#{SKOOB_URL}#{publication_slug}"
   end
 end

--- a/app/models/skoob_urls.rb
+++ b/app/models/skoob_urls.rb
@@ -1,8 +1,20 @@
 class SkoobUrls
   SKOOB_URL = 'https://www.skoob.com.br'
 
-  def self.bookshelf_read(user_id, page = 1)
-    "#{SKOOB_URL}/v1/bookcase/books/#{user_id}/shelf_id:0/page:#{page}/limit:36"
+  def self.bookshelf_url(user_id:, page: 1, type:)
+    "#{SKOOB_URL}/v1/bookcase/#{type}/#{user_id}/shelf_id:0/page:#{page}/limit:36"
+  end
+
+  def self.books_shelf_url(user_id, page = 1)
+    bookshelf_url(user_id: user_id, page: page, type: 'books')
+  end
+
+  def self.comics_shelf_url(user_id, page = 1)
+    bookshelf_url(user_id: user_id, page: page, type: 'comics')
+  end
+
+  def self.magazines_shelf_url(user_id, page = 1)
+    bookshelf_url(user_id: user_id, page: page, type: 'magazines')
   end
 
   def self.book_page_url(book_slug)

--- a/app/models/skoob_user.rb
+++ b/app/models/skoob_user.rb
@@ -1,7 +1,7 @@
 require 'mechanize'
 
 class SkoobUser < ActiveRecord::Base
-  has_many :books, primary_key: 'skoob_user_id'
+  has_many :publications, primary_key: 'skoob_user_id'
 
   def self.login(email, password)
     user = find_or_initialize_by(email: email)
@@ -33,9 +33,9 @@ class SkoobUser < ActiveRecord::Base
   def import_library
     update(import_status: 1, not_imported: {})
 
-    books = yield(self)
+    publications = yield(self)
 
-    update(import_status: 0, not_imported: books[:duplicated])
+    update(import_status: 0, not_imported: publications[:duplicated])
   end
 
   def mechanize

--- a/app/views/crawlers/_importing_card.html.erb
+++ b/app/views/crawlers/_importing_card.html.erb
@@ -21,7 +21,6 @@
             <%= user.skoob_user_id %>
           </dd>
 
-          <dt><br />Livros importados</dt>
           <dd data-count>
           </dd>
         </dl>

--- a/app/views/crawlers/_table_card.html.erb
+++ b/app/views/crawlers/_table_card.html.erb
@@ -11,6 +11,7 @@
             <th scope="col">Autor(a)</th>
             <th scope="col">ISBN</th>
             <th scope="col">Editora</th>
+            <th scope="col">Tipo</th>
           </tr>
         </thead>
         <tbody data-table-card-body>

--- a/db/migrate/20230711112832_rename_books_count_to_publications_count_in_skoob_users.rb
+++ b/db/migrate/20230711112832_rename_books_count_to_publications_count_in_skoob_users.rb
@@ -1,0 +1,5 @@
+class RenameBooksCountToPublicationsCountInSkoobUsers < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :skoob_users, :books_count, :publications_count
+  end
+end

--- a/db/migrate/20230711112942_rename_books_to_publications.rb
+++ b/db/migrate/20230711112942_rename_books_to_publications.rb
@@ -1,0 +1,5 @@
+class RenameBooksToPublications < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :books, :publications
+  end
+end

--- a/db/migrate/20230711113040_rename_skoob_book_id_to_skoob_publication_id_in_publications.rb
+++ b/db/migrate/20230711113040_rename_skoob_book_id_to_skoob_publication_id_in_publications.rb
@@ -1,0 +1,5 @@
+class RenameSkoobBookIdToSkoobPublicationIdInPublications < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :publications, :skoob_book_id, :skoob_publication_id
+  end
+end

--- a/db/migrate/20230711123057_add_publication_type_to_publications.rb
+++ b/db/migrate/20230711123057_add_publication_type_to_publications.rb
@@ -1,0 +1,5 @@
+class AddPublicationTypeToPublications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :publications, :publication_type, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,20 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_07_194634) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_11_123057) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "books", id: :serial, force: :cascade do |t|
+  create_table "publications", id: :serial, force: :cascade do |t|
     t.integer "skoob_user_id"
     t.string "title"
     t.string "author"
     t.string "isbn"
     t.string "publisher"
     t.integer "year"
-    t.integer "skoob_book_id"
+    t.integer "skoob_publication_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer "publication_type", default: 0
   end
 
   create_table "skoob_users", id: :serial, force: :cascade do |t|
@@ -31,7 +32,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_07_194634) do
     t.integer "skoob_user_id"
     t.integer "import_status", default: 0
     t.jsonb "not_imported", default: {}, null: false
-    t.integer "books_count", default: 0
+    t.integer "publications_count", default: 0
   end
 
 end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,13 +1,13 @@
-namespace :books do
-  desc 'Import books from skoob and persist them in the database'
+namespace :skoob do
+  desc 'Delete publications older than 1 day or with null created_at'
   task cleanup: :environment do
-    older_or_null_books = Book.where("created_at <= ? OR created_at IS NULL", 1.day.ago)
-    counter = older_or_null_books.count
+    publications = Publication.where("created_at <= ? OR created_at IS NULL", 1.day.ago)
+    counter = publications.count
 
     if counter > 0
-      older_or_null_books.destroy_all
+      publications.destroy_all
 
-      message = "#{counter} books deleted by the cleanup task"
+      message = "#{counter} publications deleted by the cleanup task"
       Slack::Message.send(message)
     end
   end

--- a/lib/tasks/skoob.rake
+++ b/lib/tasks/skoob.rake
@@ -1,5 +1,5 @@
 namespace :skoob do
-  desc 'Import books from skoob and persist them in the database'
+  desc 'Import publications from skoob and persist them in the database'
   task import: :environment do
     require 'io/console'
 
@@ -13,12 +13,12 @@ namespace :skoob do
 
     begin
       user = SkoobUser.login(email, password)
-      Skoob.fetch_books!(user)
+      Skoob.fetch_publications!(user)
 
       puts
       puts "Done! Your Skoob ID is #{skoob.user.skoob_user_id.to_s.green}"
       puts
-      puts 'To generate your csv file, run:'
+      puts 'To generate your CSV file, run:'
       puts "bin/rake skoob:csv:generate #{skoob.user.skoob_user_id}".green
     rescue InvalidCredentialsError => e
       puts


### PR DESCRIPTION
[An issue](https://github.com/arturcp/skoob-exporter/issues/77) was opened pointing to the fact that Skoob does not have only books, but also comics and magazines. After marking a publication as "read", if you click again on the plus sign you can select the type of the publication:

<img width="789" alt="image" src="https://github.com/arturcp/skoob-exporter/assets/523071/ea459379-dd3c-4174-8472-ec5073243bb5">

Because of that, you can find the publications in different shelves:

<img width="522" alt="image" src="https://github.com/arturcp/skoob-exporter/assets/523071/6331a532-f35c-4880-b1bf-11b1a581e0da">

Thinking on that, there is a structural change that needs to be done on the project. Book and book-related entities should be renamed to `publication`, and the code should be changed accordingly, not only to import everything from different shelves, but also to display the publication type to the users at the end of the process:

<img width="1107" alt="Captura de Tela 2023-07-11 às 10 59 27" src="https://github.com/arturcp/skoob-exporter/assets/523071/94f9f247-75df-4e08-80ab-10cdb646f341">

