### PR TITLE
Run db:migrate after deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 worker: bundle exec sidekiq -c 3 -v
-web: bundle exec rails server -p $PORT
+web: bundle exec rake db:migrate && bundle exec rails server -p $PORT


### PR DESCRIPTION
Every time we deploy a new code to production, it is important to run `bundle exec rake db:migrate` to ensure the database is updated.

This process is currently being done manually after each deploy.