### PR TITLE
Block button to prevent multiple requests

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,8 +2,10 @@
 
 import Feedback from "./lib/feedback";
 import ImportStatus from "./lib/import-status";
+import Login from "./lib/login";
 
 document.addEventListener('DOMContentLoaded', () => {
   new Feedback();
   new ImportStatus();
+  new Login();
 });

--- a/app/javascript/lib/login.js
+++ b/app/javascript/lib/login.js
@@ -1,0 +1,13 @@
+export default class Login {
+  constructor() {
+    const form = document.getElementById('crawler-form');
+    const submitButton = document.getElementById('crawler-submit');
+
+    if (form) {
+      form.addEventListener('submit', () => {
+        submitButton.disabled = true;
+        submitButton.value = 'Aguarde...';
+      });
+    }
+  }
+}

--- a/app/views/crawlers/index.html.erb
+++ b/app/views/crawlers/index.html.erb
@@ -22,7 +22,7 @@
   <div class="col-md-4 login-box">
     <input type="hidden" value="<% request.fullpath %>">
     <input type="hidden" value="<% request.protocol %>">
-    <%= form_tag crawlers_path, class: 'form-signin' do %>
+    <%= form_tag crawlers_path, class: 'form-signin', id: 'crawler-form' do %>
       <div class="form-group">
         <label>Email</label>
         <%= text_field_tag 'email', nil, class: 'form-control' %>
@@ -38,7 +38,7 @@
       <br />
 
       <div class="form-group">
-        <%= submit_tag 'Gerar', class: 'btn btn-lg btn-primary btn-block' %>
+        <%= submit_tag 'Gerar', class: 'btn btn-lg btn-primary btn-block', id: 'crawler-submit' %>
       </div>
     <% end %>
 


### PR DESCRIPTION
When a user clicks on the `generate` button after providing login credentials, the page hangs for a while. This happens because fetching data on Skoob is a slow process, and meanwhile the user thinks nothing is happening.

The problem with this is that users tend to click multiple times on the button:

<img width="412" alt="image" src="https://github.com/arturcp/skoob-exporter/assets/523071/5c24e720-419e-4ebb-abef-e7211bdfba14">

This spawns many background jobs on our redis / sidekiq, which is not good for the server. To prevent that, I am simply blocking the `generate` button once it is clicked.