### PR TITLE
Fix js imports

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,8 +1,8 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 
-import Feedback from "./lib/feedback";
-import ImportStatus from "./lib/import-status";
-import Login from "./lib/login";
+import Feedback from "lib/feedback";
+import ImportStatus from "lib/import-status";
+import Login from "lib/login";
 
 document.addEventListener('DOMContentLoaded', () => {
   new Feedback();

--- a/app/javascript/lib/feedback.js
+++ b/app/javascript/lib/feedback.js
@@ -1,4 +1,4 @@
-import RestClient from './rest-client';
+import RestClient from 'lib/rest-client';
 
 export default class Feedback {
   constructor() {

--- a/app/javascript/lib/import-status.js
+++ b/app/javascript/lib/import-status.js
@@ -1,4 +1,4 @@
-import RestClient from './rest-client';
+import RestClient from 'lib/rest-client';
 
 const PUBLICATION_TYPES = {
   'book': 'Livro',

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -2,7 +2,7 @@
 
 pin "application", preload: true
 
-pin_all_from "app/javascript/lib", under: "/lib"
+pin_all_from "app/javascript/lib", under: "lib"
 
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true


### PR DESCRIPTION
A user tried to import books in production and the javascript files were not loaded. That happened because of the way they were using relative paths and an extra slash on the importmap.

When I made the change previously, everything worked, even on production, but basically because the browser had cached the js. Now the cache is gone and I can see the error as well.

This PR fixes the issue.