### PR TITLE
Add link to user profile on slack notification

### DIFF
--- a/app/controllers/crawlers_controller.rb
+++ b/app/controllers/crawlers_controller.rb
@@ -29,7 +29,7 @@ class CrawlersController < ApplicationController
   private
 
   def send_slack_notification(skoob_user_id)
-    message = "User #{skoob_user_id} is importing publications right now"
+    message = "User https://www.skoob.com.br/usuario/#{skoob_user_id} is importing..."
     Slack::Message.send(message)
   end
 end


### PR DESCRIPTION
There are cases where the importer fails, and I can see the errors on Slack. However, the only information I have is the user id, so I have to manually build to user profile url to contact the user.

This change will create the user profile url for me, making life a lot easier in the future.