### PR TITLE
Create rake task to cleanup user database entry

### DIFF
--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -11,4 +11,20 @@ namespace :skoob do
       Slack::Message.send(message)
     end
   end
+
+  desc 'Delete user data to allow account recreation'
+  task cleanup_user: :environment do
+    email = ENV["EMAIL"]
+
+    puts "Cleaning user data. Email: #{email}"
+
+    user = SkoobUser.find_by(email: email)
+    if user
+      user.destroy!
+    else
+      puts "User not found."
+    end
+
+    puts "Done."
+  end
 end


### PR DESCRIPTION
A user closed his account and created a new one using the same email. However, because of that, the export tool didn't work: we already saved the id of the user for the given email.

To solve that, because this is not a recurrent problem, for now I will just clean up the user data from the database using a rake task.