### PR TITLE
Export subtitle for publications

### DIFF
--- a/app/models/exporter.rb
+++ b/app/models/exporter.rb
@@ -8,7 +8,7 @@ class Exporter
   def generate_csv
     header = ['Title', 'Author', 'ISBN', 'My Rating', 'Average Rating',
         'Publisher', 'Binding', 'Year Published', 'Original Publication Year',
-        'Date Read', 'Date Added', 'Bookshelves', 'My Review']
+        'Date Read', 'Date Added', 'Bookshelves', 'My Review', 'Subtitle']
 
     publications = Publication.where(skoob_user_id: @skoob_user_id)
 
@@ -20,7 +20,7 @@ class Exporter
 
         csv << [publication.title, publication.author, publication.isbn, rating, nil,
           publication.publisher, nil, publication.year, publication.year,
-          publication.date_read, nil, nil, nil]
+          publication.date_read, nil, nil, nil, publication.subtitle]
       end
     end
   end

--- a/app/models/publications.rb
+++ b/app/models/publications.rb
@@ -74,6 +74,7 @@ class Publications
         publication = Publication.new(
           skoob_user_id: @user.skoob_user_id,
           title: edition[:titulo],
+          subtitle: edition[:subtitulo],
           author: edition[:autor],
           publisher: edition[:editora],
           year: edition[:ano].to_i,

--- a/db/migrate/20231023112542_add_subtitle_to_publication.rb
+++ b/db/migrate/20231023112542_add_subtitle_to_publication.rb
@@ -1,0 +1,5 @@
+class AddSubtitleToPublication < ActiveRecord::Migration[7.0]
+  def change
+    add_column :publications, :subtitle, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_15_215102) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_23_112542) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_15_215102) do
     t.integer "publication_type", default: 0
     t.date "date_read"
     t.float "rating"
+    t.string "subtitle"
   end
 
   create_table "skoob_users", id: :serial, force: :cascade do |t|

--- a/spec/factories/publications.rb
+++ b/spec/factories/publications.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :publication do
     skoob_user_id { Faker::Number.unique.number(digits: 6) }
     title { Faker::Book.title }
+    subtitle { Faker::Lorem.words(number: 4) }
     author { Faker::Book.author }
     isbn { Faker::Code.isbn }
     publisher { Faker::Book.publisher }

--- a/spec/models/exporter_spec.rb
+++ b/spec/models/exporter_spec.rb
@@ -2,13 +2,13 @@
 
 RSpec.describe Exporter do
   let(:skoob_user) { create(:skoob_user) }
-  let!(:publications) { [create(:publication, title: 'Book 1', author: 'Author 1', isbn: '1234567890', publisher: 'Publisher 1', year: 2022, skoob_user: skoob_user)] }
+  let!(:publications) { [create(:publication, title: 'Book 1', author: 'Author 1', isbn: '1234567890', publisher: 'Publisher 1', year: 2022, skoob_user: skoob_user, subtitle: 'Subtitle for book 1')] }
 
   describe '#generate_csv' do
     it 'generates the CSV file with the correct data' do
       exporter = Exporter.new(skoob_user.skoob_user_id)
-      expected_csv = "Title,Author,ISBN,My Rating,Average Rating,Publisher,Binding,Year Published,Original Publication Year,Date Read,Date Added,Bookshelves,My Review\n" \
-                     "Book 1,Author 1,1234567890,2.5,,Publisher 1,,2022,2022,2023-03-09,,,\n"
+      expected_csv = "Title,Author,ISBN,My Rating,Average Rating,Publisher,Binding,Year Published,Original Publication Year,Date Read,Date Added,Bookshelves,My Review,Subtitle\n" \
+                     "Book 1,Author 1,1234567890,2.5,,Publisher 1,,2022,2022,2023-03-09,,,,Subtitle for book 1\n"
 
       csv_data = exporter.generate_csv
 


### PR DESCRIPTION
Include `subtitle` for each publication on the exported .csv.

Please notice that this field is not supported by Good Reads and will not be imported. The list of accepted attributes can be found here: https://www.goodreads.com/assets/sample_export.csv