### PR TITLE
Show better error message on timeout

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -228,6 +228,10 @@ textarea.required {
   height: 20px;
 }
 
+.login-alert {
+  margin-top: 5px;
+}
+
 /* Animations */
 
 .slide-in-fwd-center {

--- a/app/controllers/crawlers_controller.rb
+++ b/app/controllers/crawlers_controller.rb
@@ -13,9 +13,12 @@ class CrawlersController < ApplicationController
 
       redirect_to crawler_path(user.skoob_user_id)
     else
-      flash[:error] = 'Invalid Credentials'
+      flash[:error] = 'Não conseguimos fazer login no Skoob. Verifique seu email e senha e tente novamente.'
       redirect_to root_path
     end
+  rescue Net::HTTPGatewayTimeout
+    flash[:error] = 'O Skoob não está respondendo, verifique se consegue logar no site deles normalmente ou tente novamente mais tarde'
+    redirect_to root_path
   end
 
   def show

--- a/app/models/skoob_user.rb
+++ b/app/models/skoob_user.rb
@@ -40,9 +40,10 @@ class SkoobUser < ActiveRecord::Base
 
   def mechanize
     @mechanize ||= begin
-      mechanize = Mechanize.new { |agent|
+      mechanize = Mechanize.new do |agent|
         agent.user_agent_alias = Mechanize::AGENT_ALIASES.keys.sample
-      }
+        agent.read_timeout = 90
+      end
 
       mechanize.agent.http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 

--- a/app/views/crawlers/index.html.erb
+++ b/app/views/crawlers/index.html.erb
@@ -53,8 +53,7 @@
 
       <% if flash[:error] %>
         <div class="alert alert-danger login-alert" role="alert">
-          Hum... não conseguimos fazer login no Skoob. Verifique seu email e senha e
-          tente novamente.
+          <%= flash[:error] %>
         </div>
         <% flash[:error] = nil %>
       <% end %>


### PR DESCRIPTION
Skoob is very unstable and many users are receiving an error because the login takes too long to complete. To help with that, I am increasing the timeout, from 60 seconds (the default value) to 90 seconds, and I am showing a better message to let users know what is happening:

<img width="402" alt="image" src="https://github.com/arturcp/skoob-exporter/assets/523071/60a794f7-fdbc-40e9-a116-49dd55993494">
